### PR TITLE
[Network] 네트워크 레이어 구축

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Environment/InfoItem.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Environment/InfoItem.swift
@@ -1,0 +1,22 @@
+//
+//  InfoItem.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Foundation
+
+enum InfoItem {
+    case baseURL
+    case kakaoKey
+    
+    var value: String {
+        switch self {
+        case .baseURL:
+            return Bundle.main.infoDictionary?["BASE_URL"] as! String
+        case .kakaoKey:
+            return Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as! String
+        }
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/DTO/Request/TestRequest.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/DTO/Request/TestRequest.swift
@@ -1,0 +1,10 @@
+//
+//  TestRequest.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+struct TestRequestDTO: Encodable {
+    let postId: Int
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/DTO/Response/TestResponse.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/DTO/Response/TestResponse.swift
@@ -1,0 +1,14 @@
+//
+//  TestResponse.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+struct TestResponseDTO: Decodable {
+    let postId: Int
+    let id: Int
+    let name: String
+    let email: String
+    let body: String
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/Error/RouterError.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/Error/RouterError.swift
@@ -1,0 +1,22 @@
+//
+//  RouterError.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Foundation
+
+enum RouterError: LocalizedError {
+    case invalidURL
+    case encoding
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "올바르지 않은 URL입니다."
+        case .encoding:
+            return "Encoding 과정에서 오류가 발생했습니다."
+        }
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/Extension/Encodable+Dictionary.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/Extension/Encodable+Dictionary.swift
@@ -1,0 +1,24 @@
+//
+//  Encodable+Dictionary.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Foundation
+
+extension Encodable {
+    func asDictionary() -> [String: Sendable] {
+        guard
+            let data = try? JSONEncoder().encode(self),
+            let dictionary = try? JSONSerialization.jsonObject(
+                with: data,
+                options: .allowFragments
+            ) as? [String: Sendable] else {
+            LoggerFactory.create(category: .data)
+                .debug("Encodable 객체 Dictionary 생성 실패")
+            return [:]
+        }
+        return dictionary
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/Protocol/Router.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/Protocol/Router.swift
@@ -1,0 +1,42 @@
+//
+//  Router.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Foundation
+import Alamofire
+
+protocol Router: URLRequestConvertible {
+    var baseURL: String { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var headers: [String: String] { get }
+    var parameters: [String: Sendable] { get }
+    var encoding: ParameterEncoding? { get }
+}
+
+extension Router {
+    func asURLRequest() throws -> URLRequest {
+        guard let url = URL(string: baseURL + path) else {
+            throw RouterError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.method = method
+        request.headers = HTTPHeaders(headers)
+        
+        if let encoding = encoding {
+            do {
+                return try encoding.encode(
+                    request,
+                    with: parameters
+                )
+            } catch {
+                throw RouterError.encoding
+            }
+        }
+        
+        return request
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/RouterList/TestRouter.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Router/RouterList/TestRouter.swift
@@ -1,0 +1,43 @@
+//
+//  TestRouter.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Alamofire
+
+enum TestRouter {
+    case test(dto: TestRequestDTO)
+}
+
+extension TestRouter: Router {
+    var baseURL: String {
+        return "https://jsonplaceholder.typicode.com"
+    }
+    
+    var path: String {
+        return "/comments"
+    }
+    
+    var method: HTTPMethod {
+        return .get
+    }
+    
+    var headers: [String : String] {
+        return [
+            "Content-Type": "application/json"
+        ]
+    }
+    
+    var parameters: [String : Sendable] {
+        switch self {
+        case .test(let dto):
+            return dto.asDictionary()
+        }
+    }
+    
+    var encoding: ParameterEncoding? {
+        return URLEncoding.default
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Service/API.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Service/API.swift
@@ -7,19 +7,12 @@
 
 import Foundation
 import Alamofire
-import OSLog
 
 final class API {
     private let session: Session
     
     init(
-        session: Session = {
-#if DEBUG
-            return Session(eventMonitors: [Monitor()])
-#else
-            return Session.default
-#endif
-        }()
+        session: Session = Session(eventMonitors: [Monitor()])
     ) {
         self.session = session
         LoggerFactory.create(category: .lifeCycle)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Service/API.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Service/API.swift
@@ -1,0 +1,48 @@
+//
+//  API.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Foundation
+import Alamofire
+import OSLog
+
+final class API {
+    private let session: Session
+    
+    init(
+        session: Session = {
+#if DEBUG
+            return Session(eventMonitors: [Monitor()])
+#else
+            return Session.default
+#endif
+        }()
+    ) {
+        self.session = session
+        LoggerFactory.create(category: .lifeCycle)
+            .debug("\(String(describing: self)), \(String(describing: #function))")
+    }
+    
+    deinit {
+        LoggerFactory.create(category: .lifeCycle)
+            .debug("\(String(describing: self)), \(String(describing: #function))")
+    }
+    
+    func request<T: Router, U: Decodable & Sendable>(api: T) async throws -> U {
+        return try await withCheckedThrowingContinuation { continuation in
+            session.request(api)
+                .validate()
+                .responseDecodable(of: U.self) { response in
+                    switch response.result {
+                    case .success(let data):
+                        continuation.resume(returning: data)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
+                }
+        }
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Service/Utils/Monitor.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Data/Network/Service/Utils/Monitor.swift
@@ -1,0 +1,52 @@
+//
+//  Monitor.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Alamofire
+import Foundation
+
+final class Monitor: EventMonitor {
+    let queue = DispatchQueue(label: "Monitor")
+    private let dateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
+        formatter.locale = .current
+        
+        return formatter
+    }()
+    
+    func requestDidFinish(_ request: Request) {
+        LoggerFactory.create(category: .data)
+            .debug(
+                """
+                == 👉 NETWORK REQUEST FINISHED
+                == * ID : \(request.id)
+                == * TIME: \(self.dateFormatter.string(from: Date()))
+                == * URL: \(String(describing: request.request?.url?.absoluteString ?? "NO URL"))
+                == * METHOD: \(String(describing: (request.request?.httpMethod ?? "NO METHOD")))
+                == * HEADER: \(String(describing: request.request?.allHTTPHeaderFields ?? [:]))
+                == * BODY: \(String(describing: (request.request?.httpBody?.toPrettyPrintedString ?? "NO BODY")))
+                """
+            )
+    }
+    
+    func request<Value>(
+        _ request: DataRequest,
+        didParseResponse response: DataResponse<Value, AFError>
+    ) {
+        LoggerFactory.create(category: .data)
+            .debug(
+                """
+                == 👈 NETWORK RESPONSE
+                == * ID : \(request.id)
+                == * TIME: \(self.dateFormatter.string(from: Date()))
+                == * URL: \(String(describing: request.request?.url?.absoluteString ?? "NO URL"))
+                == * STATUS_CODE: \(response.response?.statusCode ?? 0)
+                == * DATA: \(String(response.data?.toPrettyPrintedString ?? "NO DATA"))
+                """
+            )
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Extension/Data+Prettier.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Extension/Data+Prettier.swift
@@ -1,0 +1,33 @@
+//
+//  Data+Prettier.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import Foundation
+
+extension Data {
+    var toPrettyPrintedString: String? {
+        guard
+            let object = try? JSONSerialization.jsonObject(
+                with: self,
+                options: []
+            ),
+            let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted]
+            ),
+            let prettyPrintedString = NSString(
+                data: data,
+                encoding: String.Encoding.utf8.rawValue
+            )
+        else {
+            LoggerFactory.create(category: .etc)
+                .debug("Data toPrettyPrintedString failed")
+            return nil
+        }
+        
+        return prettyPrintedString as String
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Utils/LoggerFactory.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Utils/LoggerFactory.swift
@@ -1,0 +1,27 @@
+//
+//  LoggerFactory.swift
+//  BBANGZIP
+//
+//  Created by 조성민 on 5/17/25.
+//
+
+import OSLog
+
+final class LoggerFactory {
+    enum LoggerCategory: String {
+        case presentation
+        case domain
+        case data
+    }
+    
+    static func create(category: LoggerCategory) -> Logger {
+        return Logger(
+            subsystem: String.subsystem,
+            category: category.rawValue
+        )
+    }
+}
+
+extension String {
+    static let subsystem = "BBANGZIP-iOS.app"
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Utils/LoggerFactory.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Utils/LoggerFactory.swift
@@ -12,6 +12,8 @@ final class LoggerFactory {
         case presentation
         case domain
         case data
+        case lifeCycle
+        case etc
     }
     
     static func create(category: LoggerCategory) -> Logger {


### PR DESCRIPTION
## 🥖 What is the PR?
프로젝트 전체에서 사용할 네트워크 레이어를 구축했습니다.

<!-- PR에 대한 전반적인 설명을 적어주세요. -->

## 🥐 Changes

<!-- 작업 내용을 리스트로 작성해주세요. -->

- Logger 생성 객체 팩토리 패턴 적용
- 라우터 패턴 적용
- 범용 API 요청 및 응답 객체 구현
- 네트워크 모니터 구현
- Info plist 값 래퍼 구현

## 🥯 Thoughts

### 라우터 패턴
요청의 종류를 하나의 단위로 묶어서 관리할 수 있도록 라우터 패턴을 적용했습니다.
아래의 프로토콜에 맞게 라우터를 하나씩 작성하여 사용할 수 있습니다.

```swift
protocol Router: URLRequestConvertible {
    var baseURL: String { get }
    var path: String { get }
    var method: HTTPMethod { get }
    var headers: [String: String] { get }
    var parameters: [String: Sendable] { get }
    var encoding: ParameterEncoding? { get }
}
```

편의를 위해 테스트 라우터를 작성하여 코드에 포함시켜 놨습니다.
```swift
enum TestRouter {
    case test(dto: TestRequestDTO)
}

extension TestRouter: Router {
    var baseURL: String {
        return "https://jsonplaceholder.typicode.com"
    }
    var path: String {
        return "/comments"
    }
    var method: HTTPMethod {
        return .get
    }
    var headers: [String : String] {
        return [
            "Content-Type": "application/json"
        ]
    }
    var parameters: [String : Sendable] {
        switch self {
        case .test(let dto):
            return dto.asDictionary()
        }
    }
    var encoding: ParameterEncoding? {
        return URLEncoding.default
    }
}
```

아래는 DTO 입니다.
```swift
struct TestRequestDTO: Encodable {
    let postId: Int
}

struct TestResponseDTO: Decodable {
    let postId: Int
    let id: Int
    let name: String
    let email: String
    let body: String
}
```
하나의 라우터에서 여러 요청을 할 수 있게 enum을 통해서 관리하고, 
다양한 요청에 필요한 정보를 Encodable DTO 객체로 작성합니다.
Encodable의 extension 함수인 asDictionary() 함수를 통해서 편리하게 사용할 수 있습니다.
요청에 대한 응답을 Decodable DTO를 만들어 명시하면 응답으로 자동 매핑됩니다. (범용 API 객체 사용 예시에서 확인)

### 범용 API 객체
API 요청 및 응답을 받을 수 있는 객체를 구현했습니다.
범용적으로 사용할 수 있도록 제네릭 문법을 사용했고, async await 문법을 사용하였습니다.

```swift
func request<T: Router, U: Decodable & Sendable>(api: T) async throws -> U {
    return try await withCheckedThrowingContinuation { continuation in
        session.request(api)
            .validate()
            .responseDecodable(of: U.self) { response in
                switch response.result {
                case .success(let data):
                    continuation.resume(returning: data)
                case .failure(let error):
                    continuation.resume(throwing: error)
                }
            }
    }
}
```

제네릭 문법을 사용했기 때문에 반환값을 반드시 명시해줘야 합니다. 

```swift
let result = try await API().request ... // X
let result: [TestResponseDTO] = try await API().request ... // O
```

아래 사용 예시는 예시일 뿐 이후에 사용할 때에는 Repository에 이니셜라이저를 통해 주입을 받아서 사용해야 합니다.
```swift
Task {
    let result: [TestResponseDTO] = try await API().request(api: TestRouter.test(dto: TestRequestDTO(postId: 1)))
}
```

### Logger 팩토리 패턴 구현
Logger 생성 객체를 분리하여 사용했습니다.
해당 객체 안에 String 값인 Category를 매핑하여 사용할 수 있도록 열거형으로 관리했습니다.

```swift
import OSLog

final class LoggerFactory {
    enum LoggerCategory: String {
        case presentation
        case domain
        case data
        case lifeCycle
        case etc
    }
    
    static func create(category: LoggerCategory) -> Logger {
        return Logger(
            subsystem: String.subsystem,
            category: category.rawValue
        )
    }
}

extension String {
    static let subsystem = "BBANGZIP-iOS.app"
}
```

### 네트워크 이벤트 모니터
네트워크의 요청과 응답을 모니터링할 수 있도록 구현했습니다.
모니터링에 print를 사용하지 않고 Logger의 debug 함수를 사용했기 때문에 release에서는 확인할 수 없도록 구현했습니다.
아래 예시는 위의 테스트 요청에 대한 요청 및 응답입니다.

|요청|응답|
|:-:|:-:|
|<img width="653" alt="image" src="https://github.com/user-attachments/assets/2aa30595-ab2b-440d-90c1-6245a0e9ae66" />|<img width="670" alt="image" src="https://github.com/user-attachments/assets/d9f0810b-93a4-475c-a731-138b073c781b" />|

## 🥨 To Reviewers

위의 PR 내용 잘 읽어주세요!!
이상한 부분이나 질문 있으면 꼭 코멘트 부탁드립니다.

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #20 
