### PR TITLE
[Feature] 타이머 - 시작 시간 선택 바텀시트 구현

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Domain/Repositories/TodoRepository.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Domain/Repositories/TodoRepository.swift
@@ -18,6 +18,7 @@ protocol TodoRepository: Sendable {
     // TODO: targetDate 고려하여 추가
     func addTodo(
         categoryIndex: Int,
-        content: String
+        content: String,
+        startTime: Date?
     ) async throws
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Domain/UseCases/AddTodoUseCase.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Domain/UseCases/AddTodoUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol AddTodoUseCase {
-    func execute(categoryIndex: Int, content: String) async throws
+    func execute(categoryIndex: Int, content: String, startTime: Date?) async throws
 }
 
 final class DefaultAddTodoUseCase: AddTodoUseCase {
@@ -20,11 +20,13 @@ final class DefaultAddTodoUseCase: AddTodoUseCase {
 
     func execute(
         categoryIndex: Int,
-        content: String
+        content: String,
+        startTime: Date?
     ) async throws {
         try await repository.addTodo(
             categoryIndex: categoryIndex,
-            content: content
+            content: content,
+            startTime: startTime
         )
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Extension/DateFormatter+.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Extension/DateFormatter+.swift
@@ -1,0 +1,26 @@
+//
+//  DateFormatter+.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 8/28/25.
+//
+
+import Foundation
+
+extension DateFormatter {
+    static let taskTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.dateFormat = "a hh:mm"
+        return formatter
+    } ()
+    
+    static let repositoryTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/StartTimeView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/StartTimeView.swift
@@ -8,28 +8,9 @@
 import SwiftUI
 
 struct StartTimeView: View {
-    @Binding var selectedTime: Date?
+    @ObservedObject var viewModel: StartTimeViewModel
     @Binding var isSheetPresented: Bool
-    
-    @State private var tempTime: Date
-    
-    init(
-        selectedTime: Binding<Date?>,
-        isSheetPresented: Binding<Bool>
-    ) {
-        self._selectedTime = selectedTime
-        self._isSheetPresented = isSheetPresented
-        
-        if let existingTime = selectedTime.wrappedValue {
-            _tempTime = State(initialValue: existingTime)
-        } else {
-            var components = Calendar.current.dateComponents([.year, .month, .day], from: Date())
-            components.hour = 12
-            components.minute = 0
-            let defaultTime = Calendar.current.date(from: components) ?? Date()
-            _tempTime = State(initialValue: defaultTime)
-        }
-    }
+    let onSelect: (Date?) -> Void
     
     var body: some View {
         Text("시작 시간 설정")
@@ -49,7 +30,7 @@ struct StartTimeView: View {
     var timePicker: some View {
         DatePicker(
             "",
-            selection: $tempTime,
+            selection: $viewModel.tempTime,
             displayedComponents: .hourAndMinute
         )
         .datePickerStyle(.wheel)
@@ -60,7 +41,7 @@ struct StartTimeView: View {
     var buttons: some View {
         HStack(spacing: 15) {
             Button("취소") {
-                selectedTime = nil
+                onSelect(nil)
                 isSheetPresented = false
             }
             .buttonStyle(
@@ -71,7 +52,7 @@ struct StartTimeView: View {
             )
             
             Button("설정") {
-                selectedTime = tempTime
+                onSelect(viewModel.tempTime)
                 isSheetPresented = false
             }
             .buttonStyle(

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/StartTimeView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/StartTimeView.swift
@@ -1,0 +1,85 @@
+//
+//  StartTimeView.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 8/20/25.
+//
+
+import SwiftUI
+
+struct StartTimeView: View {
+    @Binding var selectedTime: Date?
+    @Binding var isSheetPresented: Bool
+    
+    @State private var tempTime: Date
+    
+    init(
+        selectedTime: Binding<Date?>,
+        isSheetPresented: Binding<Bool>
+    ) {
+        self._selectedTime = selectedTime
+        self._isSheetPresented = isSheetPresented
+        
+        if let existingTime = selectedTime.wrappedValue {
+            _tempTime = State(initialValue: existingTime)
+        } else {
+            var components = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+            components.hour = 12
+            components.minute = 0
+            let defaultTime = Calendar.current.date(from: components) ?? Date()
+            _tempTime = State(initialValue: defaultTime)
+        }
+    }
+    
+    var body: some View {
+        Text("시작 시간 설정")
+            .bbangFont(.title3)
+            .foregroundStyle(Color(.labelAlternative))
+            .padding(.top, 25)
+        
+        timePicker
+            .padding(.horizontal, 20)
+            .padding(.top, 32)
+        
+        buttons
+            .padding(.horizontal, 20)
+            .padding(.top, 48)
+    }
+    
+    var timePicker: some View {
+        DatePicker(
+            "",
+            selection: $tempTime,
+            displayedComponents: .hourAndMinute
+        )
+        .datePickerStyle(.wheel)
+        .labelsHidden()
+        .scaleEffect(0.9)
+    }
+    
+    var buttons: some View {
+        HStack(spacing: 15) {
+            Button("취소") {
+                selectedTime = nil
+                isSheetPresented = false
+            }
+            .buttonStyle(
+                BbangButtonStyle(
+                    style: .secondary,
+                    rightIcon: Image(.icQuit)
+                )
+            )
+            
+            Button("설정") {
+                selectedTime = tempTime
+                isSheetPresented = false
+            }
+            .buttonStyle(
+                BbangButtonStyle(
+                    style: .primary,
+                    rightIcon: Image(.icCheck)
+                )
+            )
+        }
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/StartTimeViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/StartTimeViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  StartTimeViewModel.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 8/20/25.
+//
+
+import SwiftUI
+
+@MainActor
+final class StartTimeViewModel: ObservableObject {
+    @Published var tempTime: Date
+    
+    init(selectedTime: Date?) {
+        if let existingTime = selectedTime {
+            self.tempTime = existingTime
+        } else {
+            var components = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+            components.hour = 12
+            components.minute = 0
+            self.tempTime = Calendar.current.date(from: components) ?? Date()
+        }
+    }
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
@@ -94,10 +94,6 @@ struct TaskAddView: View {
     }
     
     private func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        formatter.dateFormat = "a hh:mm"
-        return formatter.string(from: date)
+        DateFormatter.taskTimeFormatter.string(from: date)
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
@@ -41,20 +41,25 @@ struct TaskAddView: View {
             viewModel.submitTask()
         }
         .sheet(isPresented: $isStartTimeSheetPresented) {
+            let startTimeViewModel = StartTimeViewModel(selectedTime: viewModel.startTime)
             
             if #available(iOS 16.4, *) {
                 StartTimeView(
-                    selectedTime: $viewModel.startTime,
+                    viewModel: startTimeViewModel,
                     isSheetPresented: $isStartTimeSheetPresented
-                )
+                ) { selected in
+                    viewModel.startTime = selected
+                }
                 .presentationDetents([.height(454)])
                 .presentationCornerRadius(48)
                 .presentationDragIndicator(.visible)
             } else {
                 StartTimeView(
-                    selectedTime: $viewModel.startTime,
+                    viewModel: startTimeViewModel,
                     isSheetPresented: $isStartTimeSheetPresented
-                )
+                ){ selected in
+                    viewModel.startTime = selected
+                }
                 .presentationDetents([.height(454)])
                 .presentationDragIndicator(.visible)
             }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TaskAddView: View {
     @ObservedObject var viewModel: TaskAddViewModel
     @Binding var isPresented: Bool
+    @State private var isStartTimeSheetPresented: Bool = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -30,15 +31,36 @@ struct TaskAddView: View {
                 .foregroundColor(Color(.secondaryNormal))
             
             startTime
-                .padding(.top, 16)            
+                .onTapGesture {
+                    isStartTimeSheetPresented = true
+                }
+                .padding(.top, 16)
         }
         .padding(.horizontal, 20)
         .onDisappear {
             viewModel.submitTask()
         }
+        .sheet(isPresented: $isStartTimeSheetPresented) {
+            
+            if #available(iOS 16.4, *) {
+                StartTimeView(
+                    selectedTime: $viewModel.startTime,
+                    isSheetPresented: $isStartTimeSheetPresented
+                )
+                .presentationDetents([.height(454)])
+                .presentationCornerRadius(48)
+                .presentationDragIndicator(.visible)
+            } else {
+                StartTimeView(
+                    selectedTime: $viewModel.startTime,
+                    isSheetPresented: $isStartTimeSheetPresented
+                )
+                .presentationDetents([.height(454)])
+                .presentationDragIndicator(.visible)
+            }
+        }
     }
     
-    // TODO: 시간 설정 바텀시트 오픈
     var startTime: some View {
         HStack(spacing: 0) {
             Image(.icClock)
@@ -52,9 +74,9 @@ struct TaskAddView: View {
             
             Spacer()
             
-            Text("미설정")
+            Text(viewModel.startTime.map {formatDate($0)} ?? "미설정")
                 .bbangFont(.body2)
-                .foregroundStyle(Color(.labelAssistive))
+                .foregroundStyle(viewModel.startTime == nil ? Color(.labelAssistive) : Color(.labelAlternative))
                 .padding(.trailing, 8)
             
             Image(.icChevronRight)
@@ -63,5 +85,13 @@ struct TaskAddView: View {
                 .foregroundStyle(Color(.labelAssistive))
                 .frame(width: 20, height: 20)
         }
+    }
+    
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.dateFormat = "a hh:mm"
+        return formatter.string(from: date)
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddView.swift
@@ -31,6 +31,7 @@ struct TaskAddView: View {
                 .foregroundColor(Color(.secondaryNormal))
             
             startTime
+                .contentShape(Rectangle())
                 .onTapGesture {
                     isStartTimeSheetPresented = true
                 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TaskAddViewModel.swift
@@ -10,16 +10,19 @@ import SwiftUI
 @MainActor
 final class TaskAddViewModel: ObservableObject {
     @Published var newTaskText: String = ""
-    private let onAddTask: (String) -> Void
+    @Published var startTime: Date? = nil
+    private let onAddTask: (String, Date?) -> Void
 
-    init(onAddTask: @escaping (String) -> Void) {
+    init(onAddTask: @escaping (String, Date?) -> Void) {
         self.onAddTask = onAddTask
     }
 
     func submitTask() {        
         let trimmed = newTaskText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        onAddTask(trimmed)
+        
+        onAddTask(trimmed, startTime)
         newTaskText = ""
+        startTime = nil
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/View/CheckedOffView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/View/CheckedOffView.swift
@@ -22,8 +22,8 @@ struct CheckedOffView: View {
             bottomButtons
         }
         .sheet(isPresented: $viewModel.isSheetPresented) {
-            let addViewModel = TaskAddViewModel { content in
-                viewModel.addTodo(content: content)
+            let addViewModel = TaskAddViewModel { content, startTime in
+                viewModel.addTodo(content: content, startTime: startTime)
             }
             
             if #available(iOS 16.4, *) {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/ViewModel/MockTodoRepository.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/ViewModel/MockTodoRepository.swift
@@ -89,16 +89,26 @@ final class MockTodoRepository: TodoRepository {
     
     func addTodo(
         categoryIndex: Int,
-        content: String
+        content: String,
+        startTime: Date?
     ) async throws {
         let category = categories[categoryIndex]
+        
         let newTodo = TimerTodo(
             id: UUID().hashValue,
             content: content,
             isCompleted: false,
-            startTime: "00:00",
+            startTime: startTime != nil ? formatDate(startTime!) : nil,
             colorType: category.colorType
         )
         categories[categoryIndex].todos.append(newTodo)
+    }
+    
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/ViewModel/MockTodoRepository.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/ViewModel/MockTodoRepository.swift
@@ -98,17 +98,9 @@ final class MockTodoRepository: TodoRepository {
             id: UUID().hashValue,
             content: content,
             isCompleted: false,
-            startTime: startTime != nil ? formatDate(startTime!) : nil,
+            startTime: startTime.map { DateFormatter.repositoryTimeFormatter.string(from: $0) },
             colorType: category.colorType
         )
         categories[categoryIndex].todos.append(newTodo)
-    }
-    
-    private func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        formatter.dateFormat = "HH:mm"
-        return formatter.string(from: date)
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/ViewModel/TimerCheckedOffViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/View/TimerTodo/ViewModel/TimerCheckedOffViewModel.swift
@@ -44,7 +44,7 @@ final class TimerCheckedOffViewModel: ObservableObject {
         )
     }
     
-    func addTodo(content: String) {
+    func addTodo(content: String, startTime: Date?) {
         guard let index = selectedCategoryIndex else { return }
 
         let localAddUseCase = addUseCase
@@ -52,7 +52,8 @@ final class TimerCheckedOffViewModel: ObservableObject {
             do {
                 try await localAddUseCase.execute(
                     categoryIndex: index,
-                    content: content
+                    content: content,
+                    startTime: startTime
                 )
                 fetchData()
             } catch {


### PR DESCRIPTION
## 🥖 What is the PR?

타이머 완료 후 새로운 투두를 생성할 때 시작 시간을 선택하는 바텀시트를 구현했어요.
<img width="527" height="603" alt="image" src="https://github.com/user-attachments/assets/feb192b0-aef4-45b0-a7de-9c83e9482818" />


## 🥐 Changes
- 기본 DatePicker를 활용하여 시간 선택 Picker 구현
- 기본값은 오후 12시, 이전에 설정된 시각이 있다면 그대로 바텀시트가 열리도록
- 취소 버튼 선택 시 입력된 값 삭제하고 미설정 상태로
- 바텀시트 외부 회색 영역 선택 시 저장하지 않고 빠져나오도록

## 🥯 Thoughts

Picker 사용이 처음이라서 연구가 조금 필요했습니다.
- 기능명세상 5분 단위로 분이 떠야 하는데 (0분, 5분, 10분...) iOS 기본 Picker로는 단위 설정이 불가능하여 일단 1분 단위로 해두었습니다. (피그마에 기디 의견 구해둠!!)
- Picker가 처음 열릴 때 상황에 따라 기본값 분기처리가 필요해서 머리를 조금 썼습니다. (tempTime 변수 활용) 오후 12시가 기본이나, 이전에 설정된 값이 있다면 그대로 뜨도록 하였습니다.
- 기존 작업되어 있는 Todo의 startTime과 새로 만든 startTimeView의 변수를 바인딩 시켰습니다.

## 🥪 Screenshot

| 투두 생성 | 시간 설정 |
| --- | --- |
| ![AddTodo-time](https://github.com/user-attachments/assets/9b0eaa13-65ef-464c-bced-b725b9d02a22) | ![Simulator Screen Recording - iPhone 13 mini - 2025-08-20 at 18 06 09](https://github.com/user-attachments/assets/b3bacb6e-b81c-4e9b-9cd5-1d685f9529bf) |

## 🥨 To Reviewers

오랜만에 PR~ 예쁘게 봐주세요

## 🍞 Related Issues

- #34 
