### PR TITLE
[Feature] 카테고리 컬러 선택 바텀시트 구현

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/CategoryAdd/View/CategoryAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/CategoryAdd/View/CategoryAddView.swift
@@ -11,7 +11,7 @@ struct CategoryAddView: View {
     @StateObject private var viewModel = CategoryAddViewModel()
     @Environment(\.dismiss) private var dismiss
     @FocusState private var isTextFieldFocused: Bool
-    @State private var showColorPicker = false
+    @State private var isColorPickerPresented = false
     
     private var isErrorPresented: Binding<Bool> {
         Binding(
@@ -45,7 +45,7 @@ struct CategoryAddView: View {
                         selectedColor: viewModel.selectedColor,
                         onTap: {
                             isTextFieldFocused = false
-                            showColorPicker = true
+                            isColorPickerPresented = true
                         }
                     )
                     
@@ -64,10 +64,17 @@ struct CategoryAddView: View {
             .onChange(of: viewModel.isCompleted) { isCompleted in
                 if isCompleted { dismiss() }
             }
-            .sheet(isPresented: $showColorPicker) {
-                // TODO: 바텀시트 구현
-                Text("바텀시트~")
-                    .padding()
+            .sheet(isPresented: $isColorPickerPresented) {
+                if #available(iOS 16.4, *) {
+                    PickColorView(selectedColor: $viewModel.selectedColor, isPresented: $isColorPickerPresented)
+                    .presentationDetents([.height(273)])
+                    .presentationCornerRadius(48)
+                    .presentationDragIndicator(.visible)
+                } else {
+                    PickColorView(selectedColor: $viewModel.selectedColor, isPresented: $isColorPickerPresented)
+                    .presentationDetents([.height(273)])
+                    .presentationDragIndicator(.visible)
+                }
             }
         }
         .toolbar(.hidden, for: .navigationBar)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/CategoryColor/View/PickColorView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/CategoryColor/View/PickColorView.swift
@@ -1,0 +1,43 @@
+//
+//  PickColorView.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 8/31/25.
+//
+
+import SwiftUI
+
+struct PickColorView: View {
+    @Binding var selectedColor: CategoryColor
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        VStack(spacing: 0){
+            Text("카테고리 색상")
+                .bbangFont(.title3)
+                .foregroundStyle(Color(.labelAlternative))
+                .padding(.top, 25)
+            
+            LazyVGrid(
+                columns: Array(
+                    repeating: GridItem(.flexible(), spacing: 16),
+                    count: 5
+                ),
+                spacing: 20
+            ) {
+                ForEach(CategoryColor.allCases, id: \.self) { colorCase in
+                    Circle()
+                        .fill(Color(colorCase.rawValue))
+                        .frame(width: 48, height: 48)
+                        .onTapGesture {
+                            selectedColor = colorCase
+                            isPresented = false
+                        }
+                }
+            }
+            .padding(.horizontal, 36)
+            .padding(.top, 31)
+            .padding(.bottom, 40)
+        }
+    }
+}


### PR DESCRIPTION
## 🥖 What is the PR?

카테고리 추가 뷰에서 열리는 카테고리 컬러 선택 바텀시트를 구현했습니다!

<img width="301" height="629" alt="image" src="https://github.com/user-attachments/assets/571f1826-0c99-4ce0-81e3-96e93e164a63" />


## 🥐 Changes

- 카테고리 추가 뷰에서 바텀시트 열리도록
- 바텀시트에서 선택된 컬러가 반영되도록

## 🥯 Thoughts

크게 고민할 거리가 없었습니다! 쉬웠습니다!

## 🥪 Screenshot

| 카테고리 컬러 선택 |
| --- |
| ![PickColor](https://github.com/user-attachments/assets/ad78e64a-ded5-424e-a900-b63eb311bed0) |

## 🥨 To Reviewers

빨랑빨랑 리뷰 부탁드립니다!

## 🍞 Related Issues

- #38
