### PR TITLE
[Feature] 나만의 다짐 메시지 입력 바텀시트 구현

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
@@ -1,0 +1,67 @@
+//
+//  PromiseInputField.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 9/1/25.
+//
+
+import SwiftUI
+
+public struct PromiseInputField: View {
+    @Binding public var text: String
+    private let maxLength: Int = 50
+    
+    public init(text: Binding<String>
+    ) {
+        self._text = text
+    }
+    
+    public var body: some View {
+        VStack(spacing: 10) {
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $text)
+                    .frame(minHeight: 90, maxHeight: 90)
+                    .scrollContentBackground(.hidden)
+                    .padding(12)
+                    .lineSpacing(4)
+                    .lineLimit(3)
+                    .bbangFont(.body1)
+                    .foregroundColor(Color(.labelNormal))
+                    .background(Color(.componentStrong))
+                    .tint(.clear)
+                    .cornerRadius(8)
+                    .keyboardType(.default)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .onChange(of: text) { newValue in
+                        if newValue.count > maxLength {
+                            text = String(newValue.prefix(maxLength))
+                        }
+                    }
+                
+                if text.isEmpty {
+                    Text("나만의 다짐을 적어보세요")
+                        .foregroundColor(Color(.labelAssistive))
+                        .bbangFont(.body1)
+                        .padding(16)
+                }
+            }
+            
+            HStack {
+                Spacer()
+                
+                Text("\(text.count)/\(maxLength)")
+                    .bbangFont(.body3)
+                    .foregroundColor(Color(.labelAlternative))
+            }
+        }
+    }
+    
+    private func isValidInput(_ input: String) -> Bool {
+        return !input.isEmpty
+    }
+}
+
+#Preview {
+    PromiseInputField(text: .constant(""))
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
@@ -11,8 +11,7 @@ public struct PromiseInputField: View {
     @Binding public var text: String
     private let maxLength: Int = 50
     
-    public init(text: Binding<String>
-    ) {
+    public init(text: Binding<String>) {
         self._text = text
     }
     

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
@@ -19,42 +19,53 @@ public struct PromiseInputField: View {
     public var body: some View {
         VStack(spacing: 10) {
             ZStack(alignment: .topLeading) {
-                TextEditor(text: $text)
-                    .frame(minHeight: 90, maxHeight: 90)
-                    .scrollContentBackground(.hidden)
-                    .padding(12)
-                    .lineSpacing(4)
-                    .lineLimit(3)
-                    .bbangFont(.body1)
-                    .foregroundColor(Color(.labelNormal))
-                    .background(Color(.componentStrong))
-                    .tint(.clear)
-                    .cornerRadius(8)
-                    .keyboardType(.default)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                    .onChange(of: text) { newValue in
-                        if newValue.count > maxLength {
-                            text = String(newValue.prefix(maxLength))
-                        }
-                    }
+                textField
                 
-                if text.isEmpty {
-                    Text("나만의 다짐을 적어보세요")
-                        .foregroundColor(Color(.labelAssistive))
-                        .bbangFont(.body1)
-                        .padding(16)
+                if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    placeholder
                 }
             }
             
             HStack {
                 Spacer()
                 
-                Text("\(text.count)/\(maxLength)")
-                    .bbangFont(.body3)
-                    .foregroundColor(Color(.labelAlternative))
+                lengthCounter
             }
         }
+    }
+    
+    var textField: some View {
+        TextEditor(text: $text)
+            .frame(minHeight: 90, maxHeight: 90)
+            .scrollContentBackground(.hidden)
+            .padding(12)
+            .lineSpacing(4)
+            .bbangFont(.body1)
+            .foregroundColor(Color(.labelNormal))
+            .background(Color(.componentStrong))
+            .tint(.clear)
+            .cornerRadius(8)
+            .keyboardType(.default)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .onChange(of: text) { newValue in
+                if newValue.count > maxLength {
+                    text = String(newValue.prefix(maxLength))
+                }
+            }
+    }
+    
+    var placeholder: some View {
+        Text("나만의 다짐을 적어보세요")
+            .foregroundStyle(Color(.labelAssistive))
+            .bbangFont(.body1)
+            .padding(16)
+    }
+    
+    var lengthCounter: some View {
+        Text("\(text.count)/\(maxLength)")
+            .bbangFont(.body3)
+            .foregroundColor(Color(.labelAlternative))
     }
     
     private func isValidInput(_ input: String) -> Bool {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/MyPromiseView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/MyPromiseView.swift
@@ -1,0 +1,30 @@
+//
+//  MyPromiseView.swift
+//  BBANGZIP
+//
+//  Created by 김송희 on 9/1/25.
+//
+
+import SwiftUI
+
+struct MyPromiseView: View {
+    @State private var promiseText: String = ""
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("나만의 다짐 작성")
+                .bbangFont(.title3)
+                .foregroundStyle(Color(.labelAlternative))
+                .padding(.top, 25)
+            
+            PromiseInputField(text: $promiseText)
+                .padding(.horizontal, 20)
+                .padding(.top, 31)
+                .padding(.bottom, 28)
+        }
+    }
+}
+
+#Preview {
+    MyPromiseView()
+}

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/MyPromiseView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/MyPromiseView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MyPromiseView: View {
-    @State private var promiseText: String = ""
+    @State private var promiseText: String = "나만의 다짐을 적어보세요"
     
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
## 🥖 What is the PR?

투두 뷰에서 최상단 클릭 시 나타나는 나만의 다짐 메시지를 입력하는 바텀시트를 구현했어요.

<img width="422" height="886" alt="image" src="https://github.com/user-attachments/assets/798555c7-c515-48ae-bdfa-c2cdee5f6a54" />


## 🥐 Changes

- 여러 줄 입력 가능한 텍스트필드(TextEditor) 컴포넌트 구현
- 입력한 글자수 카운터 구현 & 최대 글자수 50자로 제한
- 기능명세에 따라, 디폴트 메시지를 유저가 직접 지운 후 나만의 메시지를 입력하고, 아무것도 설정하지 않거나 공백만 입력했을 때에는 placeholder가 뜨도록 구현

## 🥯 Thoughts

TextField는 익숙하지만 TextEditor는 처음 사용해 보아서 탐구가 필요했어요.
최대한 기능명세에 맞게 구현해 보았습니다! 디폴트 텍스트 & 사용자가 입력한 텍스트 & placeholer를 잘 조화시켜야 했어요.

## 🥪 Screenshot

| 기본 입력시 | 공백 입력시 |
| --- | --- |
| ![PromiseTextField](https://github.com/user-attachments/assets/9af47b1e-0a0f-4684-a955-8fa966c990da) | ![MyPromise](https://github.com/user-attachments/assets/5f384d57-23f0-4343-9600-270a116b94e9)|

## 🥨 To Reviewers

바텀시트 연결은 투두 뷰 완성되면 하겠습니다!
MVVM 패턴도 그때 다시 고민해 볼게요.

## 🍞 Related Issues

- #42
