### PR TITLE
[2차 QA반영] 투두 관련 QA를 반영합니다.

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/CalendarCellView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/CalendarCellView.swift
@@ -16,12 +16,12 @@ struct CalendarCellView: View {
         VStack(spacing: 8) {
             BbangText(
                 day,
-                font: .label4,
+                font: isSelected ? .label3 : .label4,
                 color: isSelected ? Color(.labelNormal) : Color(.labelAlternative)
             )
             BbangText(
                 "\(calendar.component(.day, from: date))",
-                font: .label4,
+                font: isSelected ? .label1 : .label4,
                 color: isSelected ? Color(.labelNormal) : Color(.labelAlternative)
             )
         }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/TaskBox.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/TaskBox.swift
@@ -13,7 +13,7 @@ struct TaskBox: View {
     var showSeperator: Bool = true
     
     var body: some View {
-        HStack(alignment: .center) {
+        HStack(alignment: .top) {
             CheckBox(
                 isChecked: viewModel.todo.isCompleted,
                 color: viewModel.todo.colorType.color,
@@ -21,6 +21,7 @@ struct TaskBox: View {
                     viewModel.toggleCompletion()
                 }
             )
+            .padding(.top, viewModel.todo.startTime == nil ? 8 : 5)
             
             VStack(spacing: 0) {
                 HStack(alignment: .center) {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/TaskBox.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/TaskBox.swift
@@ -39,6 +39,7 @@ struct TaskBox: View {
                             HStack(spacing: 3) {
                                 Image(.icClock)
                                     .resizable()
+                                    .renderingMode(.template)
                                     .frame(width: 15, height: 15)
                                     .foregroundColor(Color(.labelAssistive))
                                 Text(formattedTime)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/ViewModel/MockTodoRepository.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/ViewModel/MockTodoRepository.swift
@@ -46,7 +46,7 @@ final class MockTodoRepository: TodoRepository {
                 todos: [
                     TimerTodo(
                         id: 3,
-                        content: "자기소개서 쓰기",
+                        content: "자기소개서 쓰기 \n 아아아아",
                         isCompleted: false,
                         startTime: "11:30",
                         colorType: .Todopurple1

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/ViewModel/MockTodoRepository.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/ViewModel/MockTodoRepository.swift
@@ -64,6 +64,27 @@ final class MockTodoRepository: TodoRepository {
                         isCompleted: true,
                         startTime: nil,
                         colorType: .Todopurple1
+                    ),
+                    TimerTodo(
+                        id: 6,
+                        content: "자기소개서 쓰기 \n 아아아아",
+                        isCompleted: false,
+                        startTime: "11:30",
+                        colorType: .Todopurple1
+                    ),
+                    TimerTodo(
+                        id: 7,
+                        content: "Resume 쓰기",
+                        isCompleted: false,
+                        startTime: "13:00",
+                        colorType: .Todopurple1
+                    ),
+                    TimerTodo(
+                        id: 8,
+                        content: "인사하기",
+                        isCompleted: true,
+                        startTime: nil,
+                        colorType: .Todopurple1
                     )
                 ],
                 isStopped: true
@@ -74,7 +95,7 @@ final class MockTodoRepository: TodoRepository {
                 colorType: .Todoyellow1,
                 todos: [
                     TimerTodo(
-                        id: 6,
+                        id: 9,
                         content: "베이스",
                         isCompleted: true,
                         startTime: "16:00",

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
@@ -221,6 +221,16 @@ struct ToDoView: View {
                 }
             }
         }
+        .gesture(
+            DragGesture(minimumDistance: 30, coordinateSpace: .local)
+                .onEnded { value in
+                    if value.translation.width < -50 {
+                        viewModel.moveWeek(by: 1)
+                    } else if value.translation.width > 50 {
+                        viewModel.moveWeek(by: -1)
+                    }
+                }
+        )
     }
     
     var todoSummaryView: some View {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
@@ -266,14 +266,25 @@ struct ToDoView: View {
                 
             } else if let todo = item.asTodo {
                 let todoVM = viewModel.makeTodoViewModel(todo: todo)
-                TaskBox(
-                    viewModel: todoVM,
-                    meatballTapped: { handleMeatballTapped(for: todo) },
-                    showSeperator: true
-                )
-                .padding(.horizontal, 20)
-                .buttonStyle(PlainButtonStyle())
                 
+                if let currentIndex = viewModel.todoItems.firstIndex(where: { $0.id == item.id }) {
+                    
+                    let nextItem = viewModel.todoItems[safe: currentIndex + 1]
+                    let isLastInCategory = {
+                        if case .tailDropZone = nextItem {
+                            return true
+                        }
+                        return false
+                    }()
+                    
+                    TaskBox(
+                        viewModel: todoVM,
+                        meatballTapped: { handleMeatballTapped(for: todo) },
+                        showSeperator: !isLastInCategory
+                    )
+                    .padding(.horizontal, 20)
+                    .buttonStyle(PlainButtonStyle())
+                }
             } else {
                 Rectangle()
                     .fill(Color.clear)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
@@ -39,6 +39,7 @@ struct ToDoView: View {
                         .background(Color(.secondaryLight))
                         
                         todoSummaryView
+                            .frame(height: 17)
                             .padding(.trailing, 20)
                             .padding(.top, 20)
                     }
@@ -267,7 +268,7 @@ struct ToDoView: View {
                     labelText: .constant(category.name)
                 )
                 .padding(.leading, 20)
-                .padding(.top, 16)
+                .padding(.top, 8)
                 .onTapGesture {
                     viewModel.selectedCategoryIndex = index
                     viewModel.isAddTodoSheetPresented = true

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ToDoView.swift
@@ -25,113 +25,118 @@ struct ToDoView: View {
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            ZStack(alignment: .topTrailing) {
-                List {
-                    VStack(spacing: 0) {
-                        messageView
-                        
-                        VStack(spacing: 16) {
-                            calendarHeaderView
-                            calendarBodyView
-                                .padding(.horizontal, 20)
+            VStack {
+                ZStack(alignment: .topTrailing) {
+                    List {
+                        VStack(spacing: 0) {
+                            messageView
+                            
+                            VStack(spacing: 16) {
+                                calendarHeaderView
+                                calendarBodyView
+                                    .padding(.horizontal, 20)
+                            }
+                            .padding(.vertical, 16)
+                            .background(Color(.secondaryLight))
+                            
+                            todoSummaryView
+                                .frame(height: 17)
+                                .padding(.trailing, 20)
+                                .padding(.top, 20)
                         }
-                        .padding(.vertical, 16)
-                        .background(Color(.secondaryLight))
-                        
-                        todoSummaryView
-                            .frame(height: 17)
-                            .padding(.trailing, 20)
-                            .padding(.top, 20)
-                    }
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-                    
-                    TodoContentView
                         .listRowInsets(EdgeInsets())
                         .listRowSeparator(.hidden)
                         .listRowBackground(Color.clear)
-                }
-                .listStyle(.plain)
-                .scrollIndicators(.hidden)
-                .environment(\.defaultMinListRowHeight, 0)
-                .onAppear {
-                    viewModel.fetchData()
-                }
-                
-                if isShowMenu {
-                    Color.black.opacity(0.001)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            withAnimation(.easeOut(duration: 0.3)) {
-                                isShowMenu = false
-                            }
-                        }
-                    
-                    CustomMenu(
-                        onAddCategoryTapped: {
-                            withAnimation(.easeOut(duration: 0.3)) {
-                                isShowMenu = false
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                navigationPath.append("CategoryAdd")
-                            }
-                        },
-                        onManageCategoryTapped: {
-                            withAnimation(.easeOut(duration: 0.3)) {
-                                isShowMenu = false
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                navigationPath.append("CategoryList")
-                            }
-                        }
-                    )
-                    .padding(.top, 112)
-                    .padding(.trailing, 20)
-                }
-            }
-            .navigationDestination(for: String.self) { destination in
-                if destination == "CategoryAdd" {
-                    CategoryAddView(onDismiss: {
+                        
+                        TodoContentView
+                            .listRowInsets(EdgeInsets())
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                    }
+                    .listStyle(.plain)
+                    .scrollIndicators(.hidden)
+                    .environment(\.defaultMinListRowHeight, 0)
+                    .onAppear {
                         viewModel.fetchData()
-                    })
-                } else if destination == "CategoryList" {
-                    CategoryListView()
+                    }
+                    
+                    if isShowMenu {
+                        Color.black.opacity(0.001)
+                            .ignoresSafeArea()
+                            .onTapGesture {
+                                withAnimation(.easeOut(duration: 0.3)) {
+                                    isShowMenu = false
+                                }
+                            }
+                        
+                        CustomMenu(
+                            onAddCategoryTapped: {
+                                withAnimation(.easeOut(duration: 0.3)) {
+                                    isShowMenu = false
+                                }
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                    navigationPath.append("CategoryAdd")
+                                }
+                            },
+                            onManageCategoryTapped: {
+                                withAnimation(.easeOut(duration: 0.3)) {
+                                    isShowMenu = false
+                                }
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                    navigationPath.append("CategoryList")
+                                }
+                            }
+                        )
+                        .padding(.top, 112)
+                        .padding(.trailing, 20)
+                    }
                 }
-            }
-            .sheet(isPresented: $viewModel.isAddTodoSheetPresented) {
-                let addViewModel = TaskAddViewModel { content, startTime in
-                    viewModel.addTodo(content: content)
+                .navigationDestination(for: String.self) { destination in
+                    if destination == "CategoryAdd" {
+                        CategoryAddView(onDismiss: {
+                            viewModel.fetchData()
+                        })
+                    } else if destination == "CategoryList" {
+                        CategoryListView()
+                    }
+                }
+                .sheet(isPresented: $viewModel.isAddTodoSheetPresented) {
+                    let addViewModel = TaskAddViewModel { content, startTime in
+                        viewModel.addTodo(content: content)
+                    }
+                    
+                    if #available(iOS 16.4, *) {
+                        TaskAddView(
+                            viewModel: addViewModel,
+                            isPresented: $viewModel.isAddTodoSheetPresented
+                        )
+                        .presentationDetents([.height(190)])
+                        .presentationCornerRadius(48)
+                        .presentationDragIndicator(.visible)
+                    } else {
+                        TaskAddView(
+                            viewModel: addViewModel,
+                            isPresented: $viewModel.isAddTodoSheetPresented
+                        )
+                        .presentationDetents([.height(190)])
+                        .presentationDragIndicator(.hidden)
+                    }
+                }
+                .sheet(isPresented: $viewModel.isWriteMessageSheetPresented) {
+                    if #available(iOS 16.4, *) {
+                        MyPromiseView()
+                            .presentationDetents([.height(230)])
+                            .presentationCornerRadius(48)
+                            .presentationDragIndicator(.visible)
+                    } else {
+                        MyPromiseView()
+                            .presentationDetents([.height(230)])
+                            .presentationDragIndicator(.hidden)
+                    }
                 }
                 
-                if #available(iOS 16.4, *) {
-                    TaskAddView(
-                        viewModel: addViewModel,
-                        isPresented: $viewModel.isAddTodoSheetPresented
-                    )
-                    .presentationDetents([.height(190)])
-                    .presentationCornerRadius(48)
-                    .presentationDragIndicator(.visible)
-                } else {
-                    TaskAddView(
-                        viewModel: addViewModel,
-                        isPresented: $viewModel.isAddTodoSheetPresented
-                    )
-                    .presentationDetents([.height(190)])
-                    .presentationDragIndicator(.hidden)
-                }
-            }
-            .sheet(isPresented: $viewModel.isWriteMessageSheetPresented) {
-                if #available(iOS 16.4, *) {
-                    MyPromiseView()
-                    .presentationDetents([.height(230)])
-                    .presentationCornerRadius(48)
-                    .presentationDragIndicator(.visible)
-                } else {
-                    MyPromiseView()
-                    .presentationDetents([.height(230)])
-                    .presentationDragIndicator(.hidden)
-                }
+                Spacer()
+                    .frame(height: 28)
             }
         }
     }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Utilities/SubscriptArray.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Utilities/SubscriptArray.swift
@@ -1,0 +1,12 @@
+//
+//  SubscriptArray.swift
+//  BBANGZIP
+//
+//  Created by 최유빈 on 9/24/25.
+//
+
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}


### PR DESCRIPTION
## 🥖 What is the PR?

투두 뷰 관련 QA (노션 상 담당 부분)을 반영하였습니다.

## 🥐 Changes

- [x] 할 일 목록 맨 마지막 항목 하단 선 제거
- [ ] 바텀시트 상단 여백 고정 필요 
- [x] 선택된 날짜 Focus 필요 (Bold, 색 진하게)
- [x] 주간 캘린더 스와이프 구현 
- [x] 캘린더 - 통계 - 첫번째 카테고리 사이 간격 체크
- [x] 할일이 두줄 이상이면 체크박스 정렬 첫번째 줄에 맞춰 정렬
- [x] 할일 화면 하단 여백 추가 (28px)
- [x] 할일 시간 색상 수정 (Label/Assistive 색상)

## 🥯 Thoughts

이 바텀 시트 상단 고정 같은 경우는 텍스트필드를 클릭하면 키보드 높이떄문에 자동으로 올라간다고 하는데 일단 지금은.. 당장 해결하기엔 시간이 조금 부족할 것 같아서 다같이 해결해보면 좋을 것 같아요.. 

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #53 
