### PR TITLE
[Feature] timer 완료시 todo view API 연결

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
@@ -167,11 +167,13 @@ public struct ContentView: View {
         let fetchUseCase = DefaultFetchTodosUseCase(repository: repo)
         let toggleUseCase = TimerToggleTodoCompletionUseCase(todoRepository: repo)
         let addUseCase = DefaultAddTodoUseCase(repository: repo)
+        let editUseCase = DefaultEditTodoUseCase(repository: repo)
         
         let checkedOffViewModel = TimerCheckedOffViewModel(
             fetchUseCase: fetchUseCase,
             toggleUseCase: toggleUseCase,
-            addUseCase: addUseCase
+            addUseCase: addUseCase,
+            editUseCase: editUseCase
         )
         
         return CheckedOffView(

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Domain/UseCase/Timer/EditTodoUseCase.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Domain/UseCase/Timer/EditTodoUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  EditTodoUseCase.swift
+//  BBANGZIP
+//
+//  Created by 송여경 on 1/4/26.
+//
+
+import Foundation
+
+protocol EditTodoUseCase: Sendable {
+    func execute(
+        id: Int,
+        content: String
+    ) async throws
+}
+
+final class DefaultEditTodoUseCase: EditTodoUseCase {
+    private let repository: TodoRepository
+    
+    init(repository: TodoRepository) {
+        self.repository = repository
+    }
+    
+    func execute(
+        id: Int,
+        content: String
+    ) async throws {
+        try await repository.editTodo(
+            id: id,
+            content: content
+        )
+    }
+}
+

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
@@ -93,6 +93,7 @@ private extension CheckedOffView {
                 }
                 Spacer(minLength: 50)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .scrollIndicators(.hidden)
     }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
@@ -33,8 +33,10 @@ struct CheckedOffView: View {
     let onStartAdditionalTimer: () -> Void
     
     @State private var keyboardHeight: CGFloat = 0
+    @State private var addTodoViewModel: TodoAddViewModel? = nil
+    @State private var lastPresentedSheet: SheetType? = nil
     
-    enum SheetType: Identifiable {
+    enum SheetType: Identifiable, Equatable {
         case addTodo(Category)
         case editTodo(TimerTodo)
         
@@ -45,6 +47,10 @@ struct CheckedOffView: View {
             case .editTodo(let todo):
                 return "edit_\(todo.id)"
             }
+        }
+        
+        static func == (lhs: SheetType, rhs: SheetType) -> Bool {
+            lhs.id == rhs.id
         }
     }
     
@@ -67,49 +73,62 @@ struct CheckedOffView: View {
             scrollContent
             bottomButtons
         }
-        .sheet(item: $activeSheet) { sheetType in
-            switch sheetType {
-            case .addTodo(let category):
-                let addDetentHeight: CGFloat = keyboardHeight > 0 ? 170 : 190
-                let addViewModel = TodoAddViewModel(
-                    addTodoUseCase: viewModel.addUseCase,
-                    categoryId: category.id,
-                    targetDate: viewModel.currentTargetDate
-                )
-                
-                TodoAddView(
-                    viewModel: addViewModel,
-                    isPresented: Binding(
-                        get: { activeSheet != nil },
-                        set: { if !$0 { activeSheet = nil } }
+        .sheet(
+            item: $activeSheet,
+            onDismiss: {
+                handleSheetDismiss()
+            },
+            content: { sheetType in
+                switch sheetType {
+                    
+                case .addTodo(let category):
+                    let addDetentHeight: CGFloat = keyboardHeight > 0 ? 170 : 190
+                    
+                    let vm = addTodoViewModel ?? TodoAddViewModel(
+                        addTodoUseCase: viewModel.addUseCase,
+                        categoryId: category.id,
+                        targetDate: viewModel.currentTargetDate
                     )
-                )
-                .presentationDetents([.height(addDetentHeight)])
-                .presentationCornerRadius(48)
-                .presentationDragIndicator(.visible)
-                
-            case .editTodo(let todo):
-                let detentHeight: CGFloat = keyboardHeight > 0 ? 145 : 151
-                
-                TodoContentEditView(
-                    originalTodo: todo.content,
-                    isPresented: Binding(
-                        get: { activeSheet != nil },
-                        set: { if !$0 { activeSheet = nil } }
-                    ),
-                    onSave: { newContent in
-                        try await viewModel.updateTodoContent(
-                            todoId: todo.id,
-                            newContent: newContent
+                    
+                    TodoAddView(
+                        viewModel: vm,
+                        isPresented: Binding(
+                            get: { activeSheet != nil },
+                            set: { presented in
+                                if !presented { activeSheet = nil }
+                            }
                         )
-                    }
-                )
-                .ignoresSafeArea(.keyboard)
-                .presentationDetents([.height(detentHeight)])
-                .presentationCornerRadius(48)
-                .presentationDragIndicator(.visible)
+                    )
+                    .ignoresSafeArea(.keyboard)
+                    .presentationDetents([.height(addDetentHeight)])
+                    .presentationCornerRadius(48)
+                    .presentationDragIndicator(.visible)
+                    
+                case .editTodo(let todo):
+                    let detentHeight: CGFloat = keyboardHeight > 0 ? 145 : 151
+                    
+                    TodoContentEditView(
+                        originalTodo: todo.content,
+                        isPresented: Binding(
+                            get: { activeSheet != nil },
+                            set: { presented in
+                                if !presented { activeSheet = nil }
+                            }
+                        ),
+                        onSave: { newContent in
+                            try await viewModel.updateTodoContent(
+                                todoId: todo.id,
+                                newContent: newContent
+                            )
+                        }
+                    )
+                    .ignoresSafeArea(.keyboard)
+                    .presentationDetents([.height(detentHeight)])
+                    .presentationCornerRadius(48)
+                    .presentationDragIndicator(.visible)
+                }
             }
-        }
+        )
         .navigationBarHidden(true)
         .onAppear {
             viewModel.fetchData()
@@ -119,16 +138,44 @@ struct CheckedOffView: View {
                 keyboardHeight = h
             }
         }
+        .onChange(of: activeSheet) { _, newValue in
+            if let newValue {
+                lastPresentedSheet = newValue
+                
+                if case .addTodo(let category) = newValue {
+                    addTodoViewModel = TodoAddViewModel(
+                        addTodoUseCase: viewModel.addUseCase,
+                        categoryId: category.id,
+                        targetDate: viewModel.currentTargetDate
+                    )
+                }
+            }
+        }
     }
 }
 
 private extension CheckedOffView {
     
+    func handleSheetDismiss() {
+        guard let last = lastPresentedSheet else { return }
+        
+        switch last {
+        case .addTodo:
+            addTodoViewModel?.addTodo { [weak viewModel] in
+                viewModel?.fetchData()
+            }
+            addTodoViewModel = nil
+            
+        case .editTodo:
+            break
+        }
+        
+        lastPresentedSheet = nil
+    }
+    
     var navBar: some View {
         HStack {
-            Button(action: {
-                onBackToTimer()
-            }) {
+            Button(action: { onBackToTimer() }) {
                 Image(.icChevronLeft)
                     .foregroundColor(Color(.labelAlternative))
                     .padding(.leading, 16)
@@ -151,14 +198,8 @@ private extension CheckedOffView {
     var scrollContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                ForEach(
-                    Array(viewModel.categories.enumerated()),
-                    id: \.element.id
-                ) { index, category in
-                    categorySection(
-                        for: category,
-                        at: index
-                    )
+                ForEach(Array(viewModel.categories.enumerated()), id: \.element.id) { index, category in
+                    categorySection(for: category, at: index)
                 }
                 Spacer(minLength: 50)
             }
@@ -169,34 +210,27 @@ private extension CheckedOffView {
     
     var bottomButtons: some View {
         HStack(spacing: 8) {
-            Button("30분 더") {
-                onStartAdditionalTimer()
-            }
-            .buttonStyle(
-                BbangButtonStyle(
-                    style: .secondary,
-                    rightIcon: Image(.icPlusThick)
+            Button("30분 더") { onStartAdditionalTimer() }
+                .buttonStyle(
+                    BbangButtonStyle(
+                        style: .secondary,
+                        rightIcon: Image(.icPlusThick)
+                    )
                 )
-            )
-            .frame(width: 140)
+                .frame(width: 140)
             
-            Button("종료하기") {
-                onBackToTimer()
-            }
-            .buttonStyle(
-                BbangButtonStyle(
-                    style: .primary,
-                    rightIcon: Image(.icQuit)
+            Button("종료하기") { onBackToTimer() }
+                .buttonStyle(
+                    BbangButtonStyle(
+                        style: .primary,
+                        rightIcon: Image(.icQuit)
+                    )
                 )
-            )
         }
         .padding(.horizontal, 20)
     }
     
-    func categorySection(
-        for category: Category,
-        at index: Int
-    ) -> some View {
+    func categorySection(for category: Category, at index: Int) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             CategoryButton(
                 color: .constant(category.colorType.color),
@@ -209,25 +243,17 @@ private extension CheckedOffView {
             
             ForEach(category.todos) { todo in
                 let isLast = todo.id == category.todos.last?.id
-                todoRow(
-                    for: todo,
-                    showSeperator: !isLast
-                )
+                todoRow(for: todo, showSeperator: !isLast)
             }
         }
     }
     
-    func todoRow(
-        for todo: TimerTodo,
-        showSeperator: Bool
-    ) -> some View {
+    func todoRow(for todo: TimerTodo, showSeperator: Bool) -> some View {
         let todoViewModel = viewModel.makeTodoViewModel(todo: todo)
         
         return TaskBox(
             viewModel: todoViewModel,
-            meatballTapped: {
-                activeSheet = .editTodo(todo)
-            },
+            meatballTapped: { activeSheet = .editTodo(todo) },
             showSeperator: showSeperator
         )
         .padding(.horizontal, 20)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
@@ -70,6 +70,7 @@ struct CheckedOffView: View {
         .sheet(item: $activeSheet) { sheetType in
             switch sheetType {
             case .addTodo(let category):
+                let addDetentHeight: CGFloat = keyboardHeight > 0 ? 170 : 190
                 let addViewModel = TodoAddViewModel(
                     addTodoUseCase: viewModel.addUseCase,
                     categoryId: category.id,
@@ -83,7 +84,7 @@ struct CheckedOffView: View {
                         set: { if !$0 { activeSheet = nil } }
                     )
                 )
-                .presentationDetents([.height(190)])
+                .presentationDetents([.height(addDetentHeight)])
                 .presentationCornerRadius(48)
                 .presentationDragIndicator(.visible)
                 

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
@@ -169,7 +169,6 @@ private extension CheckedOffView {
     var bottomButtons: some View {
         HStack(spacing: 8) {
             Button("30분 더") {
-                print("30분 뒤 버튼 눌림!")
                 onStartAdditionalTimer()
             }
             .buttonStyle(
@@ -181,7 +180,6 @@ private extension CheckedOffView {
             .frame(width: 140)
             
             Button("종료하기") {
-                print("종료하기 버튼 눌림!!")
                 onBackToTimer()
             }
             .buttonStyle(

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/View/CheckedOffView.swift
@@ -5,12 +5,50 @@
 //  Created by 송여경 on 5/23/25.
 //
 
+import Combine
 import SwiftUI
+
+extension Publishers {
+    static var keyboardHeight: AnyPublisher<CGFloat, Never> {
+        let willShow: AnyPublisher<CGFloat, Never> =
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .compactMap { $0.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect }
+            .map { $0.height }
+            .eraseToAnyPublisher()
+        
+        let willHide: AnyPublisher<CGFloat, Never> =
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .map { _ in CGFloat(0) }
+            .eraseToAnyPublisher()
+        
+        return willShow
+            .merge(with: willHide)
+            .eraseToAnyPublisher()
+    }
+}
 
 struct CheckedOffView: View {
     @StateObject private var viewModel: TimerCheckedOffViewModel
     let onBackToTimer: () -> Void
     let onStartAdditionalTimer: () -> Void
+    
+    @State private var keyboardHeight: CGFloat = 0
+    
+    enum SheetType: Identifiable {
+        case addTodo(Category)
+        case editTodo(TimerTodo)
+        
+        var id: String {
+            switch self {
+            case .addTodo(let category):
+                return "add_\(category.id)"
+            case .editTodo(let todo):
+                return "edit_\(todo.id)"
+            }
+        }
+    }
+    
+    @State private var activeSheet: SheetType? = nil
     
     init(
         viewModel: TimerCheckedOffViewModel,
@@ -29,19 +67,44 @@ struct CheckedOffView: View {
             scrollContent
             bottomButtons
         }
-        .sheet(isPresented: $viewModel.isSheetPresented) {
-            if let selectedCategory = viewModel.selectedCategory {
+        .sheet(item: $activeSheet) { sheetType in
+            switch sheetType {
+            case .addTodo(let category):
                 let addViewModel = TodoAddViewModel(
                     addTodoUseCase: viewModel.addUseCase,
-                    categoryId: selectedCategory.id,
+                    categoryId: category.id,
                     targetDate: viewModel.currentTargetDate
                 )
-
+                
                 TodoAddView(
                     viewModel: addViewModel,
-                    isPresented: $viewModel.isSheetPresented
+                    isPresented: Binding(
+                        get: { activeSheet != nil },
+                        set: { if !$0 { activeSheet = nil } }
+                    )
                 )
                 .presentationDetents([.height(190)])
+                .presentationCornerRadius(48)
+                .presentationDragIndicator(.visible)
+                
+            case .editTodo(let todo):
+                let detentHeight: CGFloat = keyboardHeight > 0 ? 145 : 151
+                
+                TodoContentEditView(
+                    originalTodo: todo.content,
+                    isPresented: Binding(
+                        get: { activeSheet != nil },
+                        set: { if !$0 { activeSheet = nil } }
+                    ),
+                    onSave: { newContent in
+                        try await viewModel.updateTodoContent(
+                            todoId: todo.id,
+                            newContent: newContent
+                        )
+                    }
+                )
+                .ignoresSafeArea(.keyboard)
+                .presentationDetents([.height(detentHeight)])
                 .presentationCornerRadius(48)
                 .presentationDragIndicator(.visible)
             }
@@ -49,6 +112,11 @@ struct CheckedOffView: View {
         .navigationBarHidden(true)
         .onAppear {
             viewModel.fetchData()
+        }
+        .onReceive(Publishers.keyboardHeight) { h in
+            withAnimation(.easeOut(duration: 0.2)) {
+                keyboardHeight = h
+            }
         }
     }
 }
@@ -136,8 +204,7 @@ private extension CheckedOffView {
                 labelText: .constant(category.name)
             )
             .onTapGesture {
-                viewModel.selectedCategoryIndex = index
-                viewModel.isSheetPresented = true
+                activeSheet = .addTodo(category)
             }
             .padding(.leading, 20)
             
@@ -160,16 +227,11 @@ private extension CheckedOffView {
         return TaskBox(
             viewModel: todoViewModel,
             meatballTapped: {
-                handleMeatballTapped(for: todo)
+                activeSheet = .editTodo(todo)
             },
             showSeperator: showSeperator
         )
         .padding(.horizontal, 20)
-    }
-    
-    func handleMeatballTapped(for todo: TimerTodo) {
-        print("미트볼 버튼 눌림! - \(todo.content)")
-        // TODO: 메뉴 또는 편집 기능 구현
     }
 }
 

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/ViewModel/TimerCheckedOffViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TimerTodo/ViewModel/TimerCheckedOffViewModel.swift
@@ -16,13 +16,14 @@ final class TimerCheckedOffViewModel: ObservableObject {
     let addUseCase: AddTodoUseCase
     private let fetchUseCase: FetchTodosUseCase
     private let toggleUseCase: ToggleTodoCompletionUseCase
+    private let editUseCase: EditTodoUseCase
     
     var selectedCategory: Category? {
         guard let index = selectedCategoryIndex,
               index < categories.count else { return nil }
         return categories[index]
     }
-
+    
     var currentTargetDate: Date {
         return Date()
     }
@@ -30,11 +31,13 @@ final class TimerCheckedOffViewModel: ObservableObject {
     init(
         fetchUseCase: FetchTodosUseCase,
         toggleUseCase: ToggleTodoCompletionUseCase,
-        addUseCase: AddTodoUseCase
+        addUseCase: AddTodoUseCase,
+        editUseCase: EditTodoUseCase
     ) {
         self.fetchUseCase = fetchUseCase
         self.toggleUseCase = toggleUseCase
         self.addUseCase = addUseCase
+        self.editUseCase = editUseCase
     }
     
     func fetchData() {
@@ -85,5 +88,10 @@ final class TimerCheckedOffViewModel: ObservableObject {
            let tIndex = categories[cIndex].todos.firstIndex(where: { $0.id == updatedTodo.id }) {
             categories[cIndex].todos[tIndex] = updatedTodo
         }
+    }
+    
+    func updateTodoContent(todoId: Int, newContent: String) async throws {
+        try await editUseCase.execute(id: todoId, content: newContent)
+        fetchData()
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/View/TodoAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/View/TodoAddView.swift
@@ -23,7 +23,9 @@ struct TodoAddView: View {
                 .padding(.top, 25)
 
             TaskInputField(text: $viewModel.newTodoTitle) {
-                isPresented = false
+                viewModel.addTodo {
+                    isPresented = false
+                }
             }
             .focused($isTextFieldFocused)
             .padding(.top, 31)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/View/TodoAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/View/TodoAddView.swift
@@ -12,35 +12,44 @@ struct TodoAddView: View {
     @ObservedObject var viewModel: TodoAddViewModel
     @Binding var isPresented: Bool
     @State private var isStartTimeSheetPresented: Bool = false
-    
+
+    @FocusState private var isTextFieldFocused: Bool
+
     var body: some View {
         VStack(spacing: 0) {
             Text("할 일 추가")
                 .bbangFont(.title3)
                 .foregroundStyle(Color(.labelAlternative))
                 .padding(.top, 25)
-            
+
             TaskInputField(text: $viewModel.newTodoTitle) {
                 isPresented = false
             }
+            .focused($isTextFieldFocused)
             .padding(.top, 31)
             .padding(.bottom, 16)
-            
+
             Rectangle()
                 .frame(height: 1)
                 .foregroundColor(Color(.secondaryNormal))
-            
+
             startTime
                 .contentShape(Rectangle())
                 .onTapGesture {
+                    isTextFieldFocused = false
                     isStartTimeSheetPresented = true
                 }
                 .padding(.top, 16)
         }
         .padding(.horizontal, 20)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                isTextFieldFocused = true
+            }
+        }
         .sheet(isPresented: $isStartTimeSheetPresented) {
             let startTimeViewModel = StartTimeViewModel(selectedTime: viewModel.startTime)
-            
+
             StartTimeView(
                 viewModel: startTimeViewModel,
                 isSheetPresented: $isStartTimeSheetPresented
@@ -52,25 +61,25 @@ struct TodoAddView: View {
             .presentationDragIndicator(.visible)
         }
     }
-    
+
     var startTime: some View {
         HStack(spacing: 0) {
             Image(.icClock)
                 .renderingMode(.template)
                 .foregroundStyle(Color(.labelAlternative))
-            
+
             Text("시작 시간")
                 .bbangFont(.body2)
                 .foregroundStyle(Color(.labelAlternative))
                 .padding(.leading, 8)
-            
+
             Spacer()
-            
-            Text(viewModel.startTime.map {formatDate($0)} ?? "미설정")
+
+            Text(viewModel.startTime.map { formatDate($0) } ?? "미설정")
                 .bbangFont(.body2)
                 .foregroundStyle(viewModel.startTime == nil ? Color(.labelAssistive) : Color(.labelAlternative))
                 .padding(.trailing, 8)
-            
+
             Image(.icChevronRight)
                 .renderingMode(.template)
                 .resizable()
@@ -78,7 +87,7 @@ struct TodoAddView: View {
                 .frame(width: 20, height: 20)
         }
     }
-    
+
     private func formatDate(_ date: Date) -> String {
         Foundation.DateFormatter.displayTimeFormatter.string(from: date)
     }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/ViewModel/TodoAddViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/ViewModel/TodoAddViewModel.swift
@@ -17,7 +17,7 @@ final class TodoAddViewModel: ObservableObject {
     private let addTodoUseCase: AddTodoUseCase
     private let categoryId: Int
     private let targetDate: Date
-
+    
     init(
         addTodoUseCase: AddTodoUseCase,
         categoryId: Int,
@@ -27,13 +27,15 @@ final class TodoAddViewModel: ObservableObject {
         self.categoryId = categoryId
         self.targetDate = targetDate
     }
-
+    
     func addTodo(onSuccess: (() -> Void)? = nil) {
         let trimmed = newTodoTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-
+        guard !isLoading else { return }
+        
         isLoading = true
-
+        errorMessage = nil
+        
         Task {
             do {
                 _ = try await addTodoUseCase.execute(
@@ -42,10 +44,13 @@ final class TodoAddViewModel: ObservableObject {
                     targetDate: targetDate,
                     startTime: startTime
                 )
-                isLoading = false
-                onSuccess?()
+                
                 newTodoTitle = ""
                 startTime = nil
+                isLoading = false
+                
+                onSuccess?()
+                
             } catch {
                 LoggerFactory.create(category: .data)
                     .error("AddTodo Failed: \(error.localizedDescription)")

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/View/TodoContentEditView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/View/TodoContentEditView.swift
@@ -38,7 +38,7 @@ struct TodoContentEditView: View {
                 text: $viewModel.newTodo,
                 onSubmit: {
                     Task {
-                        await viewModel.editTodoTitle()
+                        await viewModel.saveIfNeeded()
                         isPresented = false
                     }
                 }
@@ -51,6 +51,11 @@ struct TodoContentEditView: View {
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 isTextFieldFocused = true
+            }
+        }
+        .onDisappear {
+            Task {
+                await viewModel.saveIfNeeded()
             }
         }
     }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/ViewModel/TodoContentEditViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/ViewModel/TodoContentEditViewModel.swift
@@ -13,8 +13,10 @@ final class TodoContentEditViewModel: ObservableObject {
     @Published var newTodo: String = ""
     @Published var isLoading: Bool = false
     @Published var errorMessage: String? = nil
+    
     private let onEditTodo: (String) async throws -> Void
     private let originalTodo: String
+    private var didSave: Bool = false
     
     init(
         onEditTodo: @escaping (String) async throws -> Void,
@@ -26,16 +28,25 @@ final class TodoContentEditViewModel: ObservableObject {
     }
     
     func editTodoTitle() async {
+        await saveIfNeeded()
+    }
+    
+    func saveIfNeeded() async {
+        guard !didSave else { return }
+        
         let trimmed = newTodo.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed != originalTodo else { return }
+        let originalTrimmed = originalTodo.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != originalTrimmed else { return }
         
         isLoading = true
         errorMessage = nil
+        didSave = true
         
         do {
             try await onEditTodo(trimmed)
         } catch {
             errorMessage = "수정에 실패했어요. 잠시 후 다시 시도해 주세요."
+            didSave = false
         }
         
         isLoading = false


### PR DESCRIPTION
## 🥖 What is the PR?

<!-- PR에 대한 전반적인 설명을 적어주세요. -->

타이머 종료 후 노출되는 CheckedOffView의 할 일 추가 / 수정 바텀시트 api 연결작업을 진행했습니다. 

## 🥯 Thoughts

<!-- 깊이 고민한 내용을 작성해주세요. -->

바텀시트를 배경 터치로 닫을 경우 API가 호출되지 않거나
첫 번째 추가 이후 두 번째부터 반영되지 않는 문제가 있어 수정작업했습니다. 그리고 api 연결을 타이머에서 이어지는 todo view에 빠져있더라고요! 
이번 PR에서는 바텀시트 dismiss 경로를 일관되게 처리하고,
할 일 추가/수정 시 어떤 방식으로 닫혀도 서버 반영이 보장되도록 구조를 정리했습니다.

## 🥨 To Reviewers

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
키보드 표시 여부에 따라 바텀시트 높이가 어색해지는 문제도 UX면에서 해결하긴 햇는데 다른 todo 부분도 일관성있는 수정 작업이 필요해 보입니다.  ignoresafearea로 해결이 잘 안되는 문제를 키보드 높이 감지해서 키보드가 떴을 때, 바텀시트 높이를 줄여주는 방식으로 해결했습니다~

이번에도 테플 전 급하게 수정 버전이라 바로 머지할게요! 시간 날 때 확인해주십쇼! 

## 🍞 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #81 
