### PR TITLE
[Feature] 2026 1차 QA 반영

### DIFF
--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/CalendarCellView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/CalendarCellView.swift
@@ -21,7 +21,7 @@ struct CalendarCellView: View {
             )
             BbangText(
                 "\(calendar.component(.day, from: date))",
-                font: isSelected ? .label1 : .label4,
+                font: isSelected ? .label1 : .label2,
                 color: isSelected ? Color(.labelNormal) : Color(.labelAlternative)
             )
         }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
@@ -209,10 +209,10 @@ public struct ContentView: View {
             VStack(spacing: 4) {
                 icon
                     .renderingMode(.template)
-                    .foregroundColor(selectedTab == tag ? Color(.staticblack) : Color(.labelAssistive))
+                    .foregroundColor(selectedTab == tag ? Color(.labelStrong) : Color(.labelAssistive))
                 Text(title)
                     .font(.system(size: 10))
-                    .foregroundColor(selectedTab == tag ? Color(.staticblack) : Color(.labelAssistive))
+                    .foregroundColor(selectedTab == tag ? Color(.labelStrong) : Color(.labelAssistive))
             }
             .frame(maxWidth: .infinity)
         }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
@@ -3,6 +3,8 @@ import KakaoSDKCommon
 import KakaoSDKAuth
 
 public struct ContentView: View {
+    @State private var isTodoNavigating: Bool = false
+    
     @StateObject private var timerViewModel = TimerViewModel(
         timerUseCase: TimerUseCaseImpl(),
         breadCountUseCase: BreadCountUseCaseImpl(repository: BreadCountRepositoryImpl()),
@@ -173,7 +175,9 @@ public struct ContentView: View {
                 .tabItem { EmptyView() }
                 .tag(0)
             
-            ToDoView(viewModel: makeTodoViewModel())
+            ToDoView(viewModel: makeTodoViewModel(), onNavigationDepthChanged: { isDeep in
+                isTodoNavigating = isDeep
+            })
                 .tabItem { EmptyView() }
                 .tag(1)
             
@@ -200,7 +204,7 @@ public struct ContentView: View {
                 .fill(Color(.labelDisable))
                 .frame(height: 0.5)
         }
-        .opacity(timerViewModel.state == .running || timerViewModel.state == .paused ? 0 : 1)
+        .opacity((timerViewModel.state == .running || timerViewModel.state == .paused) || isTodoNavigating ? 0 : 1)
     }
 
     private func tabBarItem(icon: Image, title: String, tag: Int) -> some View {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/ContentView.swift
@@ -200,6 +200,7 @@ public struct ContentView: View {
                 .fill(Color(.labelDisable))
                 .frame(height: 0.5)
         }
+        .opacity(timerViewModel.state == .running || timerViewModel.state == .paused ? 0 : 1)
     }
 
     private func tabBarItem(icon: Image, title: String, tag: Int) -> some View {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/Component/PromiseInputField.swift
@@ -44,7 +44,8 @@ public struct PromiseInputField: View {
         TextEditor(text: $text)
             .frame(minHeight: 90, maxHeight: 90)
             .scrollContentBackground(.hidden)
-            .padding(12)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 12)
             .lineSpacing(4)
             .bbangFont(.body1)
             .foregroundColor(Color(.labelNormal))
@@ -70,7 +71,8 @@ public struct PromiseInputField: View {
         Text("나만의 다짐을 적어보세요")
             .foregroundStyle(Color(.labelAssistive))
             .bbangFont(.body1)
-            .padding(16)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 20)
     }
     
     var lengthCounter: some View {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/MyPage/View/ChangeProfileView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/MyPage/View/ChangeProfileView.swift
@@ -16,9 +16,10 @@ struct ChangeProfileView: View {
     
     let maxNameLength: Int = 20
     var onDismiss: (() -> Void)?
+    var onSave: ((String, String) -> Void)?
     
-    init(onDismiss: (() -> Void)? = nil) {
-        self.onDismiss = onDismiss
+    init(onSave: ((String, String) -> Void)? = nil) {
+        self.onSave = onSave
         _viewModel = StateObject(wrappedValue: ChangeProfileViewModel(
             getProfileUseCase: GetProfileUseCaseImpl(repository: ProfileRepository()),
             updateProfileUseCase: DefaultUpdateProfileUseCase(repository: ProfileRepository())
@@ -153,6 +154,15 @@ struct ChangeProfileView: View {
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled(true)
             .padding(.horizontal, 20)
+            .onSubmit {
+                guard !viewModel.nickname.isEmpty else { return }
+                isNameFieldFocused = false
+                Task {
+                    await viewModel.saveProfile()
+                    onSave?(viewModel.nickname, viewModel.commitmentMessage)
+                    dismiss()
+                }
+            }
             
             Rectangle()
                 .fill(Color(.primaryNormal))
@@ -197,9 +207,11 @@ struct ChangeProfileView: View {
     private var saveButton: some View {
         Button(action: {
             isNameFieldFocused = false
-            viewModel.saveProfile()
-            onDismiss?()
-            dismiss()
+            Task {
+                await viewModel.saveProfile()
+                onSave?(viewModel.nickname, viewModel.commitmentMessage)
+                dismiss()
+            }
         }) {
             Text("저장하기")
         }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/MyPage/View/MyPageView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/MyPage/View/MyPageView.swift
@@ -70,10 +70,9 @@ struct MyPageView: View {
                 }
                 if destination == "ChangeProfile" {
                     ChangeProfileView(
-                        onDismiss: {
-                            Task {
-                                await viewModel.fetchProfile()
-                            }
+                        onSave: { newNickname, newMessage in
+                            viewModel.nickname = newNickname
+                            viewModel.commitmentMessage = newMessage
                         }
                     )
                 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/MyPage/ViewModel/ChangeProfileViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/MyPage/ViewModel/ChangeProfileViewModel.swift
@@ -62,8 +62,8 @@ final class ChangeProfileViewModel: ObservableObject {
         isChangeProfileImageSheetPresented = true
     }
     
-    func saveProfile() {
-        updateNickName(nickname)
+    func saveProfile() async {
+        await updateNickName(nickname)
     }
 
     func showMyPromiseSheet() {
@@ -120,23 +120,16 @@ final class ChangeProfileViewModel: ObservableObject {
         }
     }
     
-    func updateNickName(_ newValue: String) {
-        Task {
-            do {
-                _ = try await updateProfileUseCase.updateNickname(
-                    nickname: newValue,
-                    currentProfileImageKey: profileImageKey
-                )
-                
-                await MainActor.run {
-                    self.nickname = newValue
-                }
-                
-                print("닉네임 변경 성공")
-            }
-            catch {
-                print("닉네임 변경 실패: ", error)
-            }
+    func updateNickName(_ newValue: String) async {
+        do {
+            _ = try await updateProfileUseCase.updateNickname(
+                nickname: newValue,
+                currentProfileImageKey: profileImageKey
+            )
+            self.nickname = newValue
+            print("닉네임 변경 성공")
+        } catch {
+            print("닉네임 변경 실패: ", error)
         }
     }
 }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/DatePickerView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/DatePickerView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-
+//TODO: selectedDate 오류 발생 시 주석 해제 
 struct DatePickerView: View {
     enum Mode { case changeDate, repeatAnotherDay }
     
@@ -60,9 +60,11 @@ struct DatePickerView: View {
                     DragGesture(minimumDistance: 30, coordinateSpace: .local)
                         .onEnded { value in
                             if value.translation.width < -50 {
-                                selectedDate = viewModel.moveMonth(by: 1)
+//                                selectedDate = viewModel.moveMonth(by: 1)
+                                viewModel.moveMonth(by: 1)
                             } else if value.translation.width > 50 {
-                                selectedDate = viewModel.moveMonth(by: -1)
+//                                selectedDate = viewModel.moveMonth(by: -1)
+                                viewModel.moveMonth(by: -1)
                             }
                         }
                 )
@@ -94,7 +96,8 @@ struct DatePickerView: View {
             
             HStack(spacing: 16) {
                 Button {
-                    selectedDate = viewModel.moveMonth(by: -1)
+//                    selectedDate = viewModel.moveMonth(by: -1)
+                    viewModel.moveMonth(by: -1)
                 } label: {
                     Image(.icChevronLeft)
                         .renderingMode(.template)
@@ -106,7 +109,8 @@ struct DatePickerView: View {
                 .buttonStyle(.plain)
                 
                 Button {
-                    selectedDate = viewModel.moveMonth(by: 1)
+//                    selectedDate = viewModel.moveMonth(by: 1)
+                    viewModel.moveMonth(by: 1)
                 } label: {
                     Image(.icChevronRight)
                         .renderingMode(.template)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/DatePickerView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/DatePickerView.swift
@@ -43,7 +43,7 @@ struct DatePickerView: View {
             Text(titleText)
                 .bbangFont(.title3)
                 .foregroundStyle(Color(.labelAlternative))
-                .padding(.top, 25)
+                .padding(.top, 36)
             
             monthHeader
                 .padding(.top, 28)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/DatePickerViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/DatePickerViewModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import Combine
-
+//TODO: selectedDate 오류 발생 시 주석 해제
 final class DatePickerViewModel: ObservableObject {
     @Published private(set) var currentMonth: Date
     @Published private(set) var days: [CalendarDay] = []
@@ -40,17 +40,27 @@ final class DatePickerViewModel: ObservableObject {
         return formatter.string(from: currentMonth)
     }
     
-    func moveMonth(by delta: Int) -> Date {
+//    func moveMonth(by delta: Int) -> Date {
+//        guard let newMonth = calendar.date(
+//            byAdding: .month,
+//            value: delta,
+//            to: currentMonth
+//        ) else {
+//            return currentMonth
+//        }
+//        currentMonth = newMonth
+//        rebuildDays()
+//        return firstDay(of: newMonth)
+//    }
+    
+    func moveMonth(by delta: Int) { 
         guard let newMonth = calendar.date(
             byAdding: .month,
             value: delta,
             to: currentMonth
-        ) else {
-            return currentMonth
-        }
+        ) else { return }
         currentMonth = newMonth
         rebuildDays()
-        return firstDay(of: newMonth)
     }
     
     func tapped(day: CalendarDay) -> Date? {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
@@ -212,7 +212,9 @@ struct ToDoView: View {
                             onDuplicate: { [weak viewModel] in
                                 viewModel?.fetchData()
                             },
-                            onChangeDate: {},
+                            onChangeDate: {
+                                viewModel.isMeatballSheetPresented = false
+                            },
                             onPatchedTitle: { [weak viewModel] _ in
                                 viewModel?.fetchData()
                             },

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
@@ -144,18 +144,22 @@ struct ToDoView: View {
                 .sheet(
                     isPresented: $viewModel.isAddTodoSheetPresented,
                     onDismiss: {
-                        if let vm = addTodoViewModel {
-                            vm.addTodo { [weak viewModel] in
-                                viewModel?.fetchData()
-                            }
-                        }
+//                        if let vm = addTodoViewModel {
+//                            vm.addTodo { [weak viewModel] in
+//                                viewModel?.fetchData()
+//                            }
+//                        }
                         addTodoViewModel = nil
                     },
                     content: {
                         if let vm = addTodoViewModel {
                             TodoAddView(
                                 viewModel: vm,
-                                isPresented: $viewModel.isAddTodoSheetPresented
+                                isPresented: $viewModel.isAddTodoSheetPresented,
+                                onSuccess: {
+                                    viewModel.fetchData()
+                                    viewModel.isAddTodoSheetPresented = false
+                                }
                             )
                             .presentationDetents([.height(190)])
                             .presentationCornerRadius(48)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
@@ -9,17 +9,23 @@ import SwiftUI
 
 struct ToDoView: View {
     private let repository = TodoRepositoryImpl()
+    var onNavigationDepthChanged: ((Bool) -> Void)? = nil
     
     @StateObject private var viewModel: TodoViewModel
     @StateObject private var categoryListViewModel: CategoryListViewModel
     @State private var addTodoViewModel: TodoAddViewModel? = nil
     @State private var selectedDate: Date? = nil
     @State private var isShowMenu: Bool = false
-    @State private var navigationPath = NavigationPath()
+    @State private var navigationPath = NavigationPath() {
+        didSet {
+            onNavigationDepthChanged?(!navigationPath.isEmpty)
+        }
+    }
     init(
         viewModel: TodoViewModel,
         selectedDate: Date? = nil,
-        isShowMenu: Bool = false
+        isShowMenu: Bool = false,
+        onNavigationDepthChanged: ((Bool) -> Void)? = nil
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.selectedDate = selectedDate
@@ -34,6 +40,7 @@ struct ToDoView: View {
                 fetchCategoriesUseCase: fetchCategoriesUseCase
             )
         )
+        self.onNavigationDepthChanged = onNavigationDepthChanged
     }
     
     var body: some View {
@@ -233,6 +240,9 @@ struct ToDoView: View {
             
             Spacer()
                 .frame(height: 28)
+        }
+        .onChange(of: navigationPath.count) { _, count in
+            onNavigationDepthChanged?(count > 0)
         }
     }
     

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/ToDoView.swift
@@ -21,6 +21,11 @@ struct ToDoView: View {
             onNavigationDepthChanged?(!navigationPath.isEmpty)
         }
     }
+    
+    @State private var dragOffset: CGFloat = 0
+    @State private var isAnimating: Bool = false
+    @State private var calendarWidth: CGFloat = 0
+    
     init(
         viewModel: TodoViewModel,
         selectedDate: Date? = nil,
@@ -144,11 +149,6 @@ struct ToDoView: View {
                 .sheet(
                     isPresented: $viewModel.isAddTodoSheetPresented,
                     onDismiss: {
-//                        if let vm = addTodoViewModel {
-//                            vm.addTodo { [weak viewModel] in
-//                                viewModel?.fetchData()
-//                            }
-//                        }
                         addTodoViewModel = nil
                     },
                     content: {
@@ -288,7 +288,18 @@ struct ToDoView: View {
             .padding(.leading, 20)
             .padding(.vertical, 6)
             
-            Button(action: { viewModel.moveWeek(by: -1) }) {
+            Button(action: {
+                guard !isAnimating else { return }
+                isAnimating = true
+                withAnimation(.easeOut(duration: 0.25)) {
+                    dragOffset = calendarWidth
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    viewModel.moveWeek(by: -1)
+                    dragOffset = 0
+                    isAnimating = false
+                }
+            }) {
                 Image(.icChevronLeft)
                     .renderingMode(.template)
                     .resizable()
@@ -298,7 +309,18 @@ struct ToDoView: View {
             }
             .buttonStyle(.plain)
             
-            Button(action: { viewModel.moveWeek(by: 1) }) {
+            Button(action: {
+                guard !isAnimating else { return }
+                isAnimating = true
+                withAnimation(.easeOut(duration: 0.25)) {
+                    dragOffset = -calendarWidth
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    viewModel.moveWeek(by: 1)
+                    dragOffset = 0
+                    isAnimating = false
+                }
+            }) {
                 Image(.icChevronRight)
                     .renderingMode(.template)
                     .resizable()
@@ -327,10 +349,66 @@ struct ToDoView: View {
     }
     
     private var calendarBodyView: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            
+            HStack(spacing: 0) {
+                weekGridView(offsetWeeks: -1)
+                    .frame(width: width)
+                weekGridView(offsetWeeks: 0)
+                    .frame(width: width)
+                weekGridView(offsetWeeks: 1)
+                    .frame(width: width)
+            }
+            .frame(width: width * 3, alignment: .leading)
+            .offset(x: -width + dragOffset)
+            .clipped()
+            .onAppear { calendarWidth = width }  // 추가
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        guard !isAnimating else { return }
+                        dragOffset = value.translation.width
+                    }
+                    .onEnded { value in
+                        guard !isAnimating else { return }
+                        let threshold = width * 0.3
+                        
+                        if value.translation.width < -threshold {
+                            isAnimating = true
+                            withAnimation(.easeOut(duration: 0.25)) {
+                                dragOffset = -width
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                viewModel.moveWeek(by: 1)
+                                dragOffset = 0
+                                isAnimating = false
+                            }
+                        } else if value.translation.width > threshold {
+                            isAnimating = true
+                            withAnimation(.easeOut(duration: 0.25)) {
+                                dragOffset = width
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                viewModel.moveWeek(by: -1)
+                                dragOffset = 0
+                                isAnimating = false
+                            }
+                        } else {
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                dragOffset = 0
+                            }
+                        }
+                    }
+            )
+        }
+        .frame(height: 70)
+    }
+
+    private func weekGridView(offsetWeeks: Int) -> some View {
         LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 7)) {
             ForEach(Array(viewModel.daysOfWeek.enumerated()), id: \.offset) { index, day in
-                if let date = viewModel.calculateDateForDay(day) {
-                    
+                if let date = viewModel.calculateDate(for: day, offsetWeeks: offsetWeeks) {
                     let selectedDateBinding = Binding<Date?>(
                         get: { selectedDate },
                         set: { new in
@@ -338,7 +416,6 @@ struct ToDoView: View {
                             viewModel.setSelectedDate(new ?? viewModel.currentDate)
                         }
                     )
-                    
                     CalendarCellView(
                         day: day,
                         date: date,
@@ -347,17 +424,6 @@ struct ToDoView: View {
                 }
             }
         }
-        .frame(height: 70)
-        .gesture(
-            DragGesture(minimumDistance: 30, coordinateSpace: .local)
-                .onEnded { value in
-                    if value.translation.width < -50 {
-                        viewModel.moveWeek(by: 1)
-                    } else if value.translation.width > 50 {
-                        viewModel.moveWeek(by: -1)
-                    }
-                }
-        )
     }
     
     var todoSummaryView: some View {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/View/TodoAddView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoAdd/View/TodoAddView.swift
@@ -14,6 +14,8 @@ struct TodoAddView: View {
     @State private var isStartTimeSheetPresented: Bool = false
 
     @FocusState private var isTextFieldFocused: Bool
+    
+    var onSuccess: (() -> Void)? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,6 +26,7 @@ struct TodoAddView: View {
 
             TaskInputField(text: $viewModel.newTodoTitle) {
                 viewModel.addTodo {
+                    onSuccess?()
                     isPresented = false
                 }
             }

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/View/TodoManageView.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/View/TodoManageView.swift
@@ -24,8 +24,8 @@ struct TodoManageView: View {
                 startTimeSection
                     .padding(.top, 24)
                 
-                alertSection
-                    .padding(.top, 20)
+//                alertSection
+//                    .padding(.top, 20)
                 
                 divider
                     .padding(.vertical, 24)

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/ViewModel/TodoManageViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoManage/ViewModel/TodoManageViewModel.swift
@@ -163,6 +163,9 @@ final class TodoManageViewModel: ObservableObject {
         do {
             let newData = try await repository.rescheduleTodo(id: todoId, targetDate: targetDate)
             onDeleted(todoId, 0, 0)
+            await MainActor.run {
+                onChangeDate()  // 성공 시 부모 sheet 닫기
+            }
             print("✅ Todo \(newData.todoId) moved to \(newData.targetDate)")
         } catch {
             print("❌ Reschedule failed: \(error)")

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoViewModel.swift
@@ -462,6 +462,33 @@ final class TodoViewModel: ObservableObject {
         }
         todoData = data
     }
+    
+    func dates(offsetWeeks: Int) -> [Date] {
+        guard let baseDate = calendar.date(byAdding: .weekOfYear, value: offsetWeeks, to: currentDate) else { return [] }
+        
+        var newDates: [Date] = []
+        var components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear, .weekday], from: baseDate)
+        components.weekday = startWeekOnSunday ? 1 : 2
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        
+        guard let startOfWeek = calendar.date(from: components) else { return [] }
+        
+        for dayOffset in 0...6 {
+            if let date = calendar.date(byAdding: .day, value: dayOffset, to: startOfWeek) {
+                newDates.append(date)
+            }
+        }
+        return newDates
+    }
+
+    func calculateDate(for day: String, offsetWeeks: Int) -> Date? {
+        guard let dayIndex = daysOfWeek.firstIndex(of: day) else { return nil }
+        let weekDates = dates(offsetWeeks: offsetWeeks)
+        guard dayIndex < weekDates.count else { return nil }
+        return weekDates[dayIndex]
+    }
 }
 
 extension TodoViewModel {

--- a/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoViewModel.swift
+++ b/BBANGZIP-iOS/BBANGZIP-iOS/Sources/Presentation/ToDo/TodoViewModel.swift
@@ -108,44 +108,11 @@ final class TodoViewModel: ObservableObject {
     
     func fetchData() {
         Task {
-            // 목데이터로 대체
-            self.todoData = TodoData(
-                myPromiseMessage: "오늘도 화이팅!",
-                summary: TodoSummary(
-                    date: "2026-03-24",
-                    totalCount: 4,
-                    completedCount: 1
-                ),
-                categories: [
-                    Category(
-                        id: 1,
-                        name: "수학",
-                        colorType: .Todoblue1,
-                        todos: [
-                            TimerTodo(id: 1, content: "미적분 3단원 풀기", isCompleted: true, startTime: "09:00", colorType: .Todoblue1, targetDate: "2025-09-01"),
-                            TimerTodo(id: 2, content: "확통 문제집 p.30", isCompleted: false, startTime: nil, colorType: .Todoblue1, targetDate: "2025-09-01")
-                        ],
-                        isStopped: false
-                    ),
-                    Category(
-                        id: 2,
-                        name: "영어",
-                        colorType: .Todogreen1,
-                        todos: [
-                            TimerTodo(id: 3, content: "단어 암기 50개", isCompleted: false, startTime: "14:00", colorType: .Todogreen1, targetDate: "2025-09-01"),
-                            TimerTodo(id: 4, content: "독해 지문 2개", isCompleted: false, startTime: nil, colorType: .Todogreen1, targetDate: "2025-09-01")
-                        ],
-                        isStopped: false
-                    )
-                ]
-            )
-            
-            //TODO: 서버 연동 후 주석해제
-            // do {
-            //     self.todoData = try await fetchUseCase.execute(date: currentTargetDate)
-            // } catch {
-            //     print("❌ 데이터 가져오기 실패: \(error)")
-            // }
+             do {
+                 self.todoData = try await fetchUseCase.execute(date: currentTargetDate)
+             } catch {
+                 print("❌ 데이터 가져오기 실패: \(error)")
+             }
         }
     }
     


### PR DESCRIPTION
## 🥖 What is the PR?

Todo, 바텀시트 관련 QA 반영

## 🥐 Changes

- 타이머 재생 중 바텀네비게이션바 숨김처리
- 카테고리 추가 바텀시트에서 입력 클릭시 바텀시트 같이 올라옴
- 투두뷰 캘린더 날짜 이동할 때 글자 크기, 높이 고정
- 다짐메세지 설정 바텀시트 모두 지워졌을때(힌트메세지)와 작성 중 줄 글 높이 안맞음
- 할일 관리 목록 바텀시트에서 미룬이 알림 삭제 
- 날짜바꾸기 바텀시트 상단 여백 좁음
- 날짜바꾸기 바텀시트 저장 후 로직 수정 (저장하기 버튼 클릭 후 설정 중이던 모든 바텀시트꺼지고, 기존에 보고 있던 할 일 화면으로 돌아와야함)
- 마이 > 프로필 변경 > 이름 수정 시 엔터 누를 때 키보드와 바텀시트 동시에 내려가야함
- 주간 캘린더 좌우 스크롤 시 모션 추가 
- 월간 캘린더 달 전환 시 선택된 날짜 유저가 직접 누르기 전까지 selected 상태 변경되지 않도록 

## 🥪 Screenshot

https://drive.google.com/drive/folders/1uutxuvqXQuMfs_SjfPPWRmmi-AQr2r7G?usp=drive_link

## 🥨 To Reviewers

화이팅

## 🍞 Related Issues

- Resolved: #84 
